### PR TITLE
Rename the new Adapter abstract method to 'GetFirstMemberOrDefault'

### DIFF
--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -134,7 +134,7 @@ namespace Microsoft.PowerShell.Cim
         }
 
         /// <inheritdoc />
-        public override PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate predicate)
+        public override PSAdaptedProperty GetFirstPropertyOrDefault(object baseObject, MemberNamePredicate predicate)
         {
             if (predicate == null)
             {

--- a/src/System.Management.Automation/engine/COM/ComAdapter.cs
+++ b/src/System.Management.Automation/engine/COM/ComAdapter.cs
@@ -84,7 +84,10 @@ namespace System.Management.Automation
             return null;
         }
 
-        protected override T GetMember<T>(object obj, MemberNamePredicate predicate)
+        /// <summary>
+        /// Returns the first PSMemberInfo whose name matches the specified <see cref="MemberNamePredicate"/>.
+        /// </summary>
+        protected override T GetFirstMemberOrDefault<T>(object obj, MemberNamePredicate predicate)
         {
             bool lookingForProperties = typeof(T).IsAssignableFrom(typeof(PSProperty));
             bool lookingForParameterizedProperties = typeof(T).IsAssignableFrom(typeof(PSParameterizedProperty));

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -159,7 +159,7 @@ namespace System.Management.Automation
                 }
             }
 
-            T retValue = msjObj.InternalAdapter.BaseGetMember<T>(msjObj._immediateBaseObject, predicate);
+            T retValue = msjObj.InternalAdapter.BaseGetFirstMemberOrDefault<T>(msjObj._immediateBaseObject, predicate);
             return retValue;
         }
 
@@ -230,7 +230,7 @@ namespace System.Management.Automation
         private static T DotNetGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
             // Don't lookup dotnet member if the object doesn't insist.
-            return msjObj.InternalBaseDotNetAdapter?.BaseGetMember<T>(msjObj._immediateBaseObject, predicate);
+            return msjObj.InternalBaseDotNetAdapter?.BaseGetFirstMemberOrDefault<T>(msjObj._immediateBaseObject, predicate);
         }
 
 

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -128,13 +128,13 @@ namespace System.Management.Automation
             return property;
         }
 
-        protected override PSProperty DoGetProperty(object obj, MemberNamePredicate predicate)
+        protected override PSProperty DoGetFirstPropertyOrDefault(object obj, MemberNamePredicate predicate)
         {
             PSAdaptedProperty property = null;
 
             try
             {
-                property = _externalAdapter.GetProperty(obj, predicate);
+                property = _externalAdapter.GetFirstPropertyOrDefault(obj, predicate);
             }
             catch (Exception exception)
             {
@@ -352,6 +352,17 @@ namespace System.Management.Automation
         /// Returns a property if it's name matches the specified <see cref="MemberNamePredicate"/>, otherwise null.
         /// </summary>
         /// <returns>An adapted property if the predicate matches, or <c>null</c>.</returns>
-        public abstract PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate propertyName);
+        public virtual PSAdaptedProperty GetFirstPropertyOrDefault(object baseObject, MemberNamePredicate predicate)
+        {
+            foreach (var property in GetProperties(baseObject))
+            {
+                if (predicate(property.Name))
+                {
+                    return property;
+                }
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

I think the new abstract method added to `Adapter` should be renamed to `GetFirstMemberOrDefault`. And the related methods should be renamed to reflect `FirstOrDefault` too.

The new method added to `PSPropertyAdapter` cannot be abstract, as that will break the existing external property adapters that derive from this type.
I changed it to a virtual method with a default implementation (loop through `GetProperties`).